### PR TITLE
cli only usage on templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mc"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc"
-version = "0.5.6"
+version = "0.5.7"
 authors = ["Brandon Clark <brandon.clark@leafgroup.com>"]
 build = "src/build.rs"
 edition = "2018"

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
-VERSION=v0.5.6
+VERSION=v0.5.7
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
   echo "Downloading debian client."

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,7 +2,7 @@ use clap::{Arg, App, AppSettings};
 
 pub fn build_cli() -> App<'static, 'static> {
     App::new("mc")
-        .version("0.5.6")
+        .version("0.5.7")
         .setting(AppSettings::DisableVersion)
         .about("\nContinuous development for todays software made easy. You can import files individually or with a \"mc.yaml\" file. Option settings will override use of \"mc.yaml\" file.")
         .arg(Arg::with_name("config")

--- a/src/handler/configs/mod.rs
+++ b/src/handler/configs/mod.rs
@@ -94,6 +94,9 @@ impl Configs {
             request.set_deploy_script(matches.value_of("deploy-script").unwrap_or("").to_owned());
             request.set_system_test(matches.value_of("system-test").unwrap_or("").to_owned());
             request.set_post_script(matches.value_of("post-script").unwrap_or("").to_owned());
+            if matches.is_present("template") || matches.is_present("parameters") || matches.is_present("template-out") {
+                request.set_no_prompt(true);
+            }
         } else {
             let mc_config = matches.value_of("config").unwrap_or("mc.yaml");
             let s = file_to_string(mc_config);


### PR DESCRIPTION
When a user is only using `mc` for templating purposes in the command line bypass prompt request for template step.